### PR TITLE
Fix country_id to accept value "AT"

### DIFF
--- a/api/v3/PostcodeAT/Getstate.php
+++ b/api/v3/PostcodeAT/Getstate.php
@@ -50,6 +50,7 @@ function civicrm_api3_postcode_a_t_getstate($params) {
 
   switch ($params['country_id']) {
     case 1014: // Österreich
+    case 'AT':
       $params['plznr'] = $params['postal_code'];
       $values = CRM_Postcodeat_Country_AT::getState($params);
       if ($values) {


### PR DESCRIPTION
This changes the `getstate` API to accept "AT" as the value for `country_id`, similar to how core accepts both the numerical country ID and the ISO code.