### PR TITLE
Add field "zustort" and improve error handling

### DIFF
--- a/CRM/Postcodeat/ImportStatistikAustria.php
+++ b/CRM/Postcodeat/ImportStatistikAustria.php
@@ -43,7 +43,7 @@ class CRM_Postcodeat_ImportStatistikAustria {
 
     //read csv file line for line
     $sql = "INSERT INTO `civicrm_statistikaustria_import` "
-      . " (`gemnr`, `gemnam38`, `okz`, `ortnam`, `skz`, `stroffi`, `plznr`, `gemnr2`)"
+      . " (`gemnr`, `gemnam38`, `okz`, `ortnam`, `skz`, `stroffi`, `plznr`, `gemnr2`, `zustort`)"
       . " VALUES ";
 
     // Results are XML so turn this into a PHP Array
@@ -53,7 +53,7 @@ class CRM_Postcodeat_ImportStatistikAustria {
 
     foreach($xml->daten->children() as $key => $element) {
       $elements = (array) $element->element;
-      if (count($elements) == 8) {
+      if (count($elements) == 9) {
         // Looks like valid data
         //escape data for database
         foreach ($elements as $n => $val) {
@@ -64,7 +64,7 @@ class CRM_Postcodeat_ImportStatistikAustria {
         $elements[3] = CRM_Postcodeat_ImportStatistikAustria::parseOrtnam($elements[3]);
 
         $values = " ('" . $elements[0] . "', '" . $elements[1] . "', '" . $elements[2] . "', '" . $elements[3] . "', '" . $elements[4] .
-          "', '" . $elements[5] . "', '" . $elements[6] . "', '" . $elements[7] . "')";
+          "', '" . $elements[5] . "', '" . $elements[6] . "', '" . $elements[7] . "', '" . $elements[8] . "')";
         CRM_Core_DAO::executeQuery($sql . $values);
       }
     }

--- a/CRM/Postcodeat/ImportStatistikAustria.php
+++ b/CRM/Postcodeat/ImportStatistikAustria.php
@@ -94,10 +94,15 @@ class CRM_Postcodeat_ImportStatistikAustria {
     return $newOrtnam;
   }
 
-  public function copy() {
+  public function copy($discardEmpty = TRUE) {
+    $check_sql = "SELECT COUNT(*) FROM `civicrm_statistikaustria_import`";
+    if ($discardEmpty && CRM_Core_DAO::singleValueQuery($check_sql) == 0) {
+      return FALSE;
+    }
     CRM_Core_DAO::executeQuery("TRUNCATE `civicrm_postcodeat`;");
     CRM_Core_DAO::executeQuery("INSERT INTO `civicrm_postcodeat` SELECT * FROM `civicrm_statistikaustria_import`");
     CRM_Core_DAO::executeQuery("TRUNCATE `civicrm_statistikaustria_import`;");
+    return TRUE;
   }
 
   /**

--- a/CRM/Postcodeat/Upgrader.php
+++ b/CRM/Postcodeat/Upgrader.php
@@ -22,4 +22,25 @@ class CRM_Postcodeat_Upgrader extends CRM_Postcodeat_Upgrader_Base {
    $this->executeSqlFile('sql/uninstall.sql');
   }
 
+  /**
+   * Add column zustort to civicrm_postcodeat and civicrm_statistikaustria_import
+   */
+  public function upgrade_1301() {
+    $column_exists = CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `civicrm_postcodeat` LIKE 'zustort';");
+    if (!$column_exists) {
+      $this->ctx->log->info("Adding column `zustort` varchar(75) NULL to table `civicrm_postcodeat`");
+      CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_postcodeat` ADD `zustort` varchar(75) NULL");
+    }
+
+    $column_exists = CRM_Core_DAO::singleValueQuery("SHOW COLUMNS FROM `civicrm_statistikaustria_import` LIKE 'zustort';");
+    if (!$column_exists) {
+      $this->ctx->log->info("Adding column `zustort` varchar(75) NULL to table `civicrm_statistikaustria_import`");
+      CRM_Core_DAO::executeQuery("ALTER TABLE `civicrm_statistikaustria_import` ADD `zustort` varchar(75) NULL");
+    }
+
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
+    return TRUE;
+  }
+
 }

--- a/api/v3/PostcodeAT/Get.php
+++ b/api/v3/PostcodeAT/Get.php
@@ -33,6 +33,7 @@ function civicrm_api3_postcode_a_t_get($params) {
     'gemnam38',
     'ortnam',
     'stroffi',
+    'zustort',
     'return',
   );
   $returnFields = array(
@@ -40,6 +41,7 @@ function civicrm_api3_postcode_a_t_get($params) {
     'plznr',
     'ortnam',
     'stroffi',
+    'zustort',
     'return',
   );
 
@@ -71,6 +73,7 @@ function civicrm_api3_postcode_a_t_get($params) {
       case 'ortnam':
       case 'stroffi':
       case 'gemnam38':
+      case 'zustort':
         if (!empty($params['strict_fields_searching'])
           && is_array($params['strict_fields_searching'])
           && in_array($field, $params['strict_fields_searching'])) {
@@ -157,11 +160,16 @@ function _civicrm_api3_postcode_a_t_get_spec(&$params) {
     'api.required' => 0,
     'title'        => 'Street address(stroffi)',
   ];
+  $params['zustort'] = [
+    'name'         => 'zustort',
+    'api.required' => 0,
+    'title'        => 'zustort',
+  ];
   $params['return'] = [
     'name'         => 'return',
     'api.required' => 0,
     'title'        => 'Return field',
-    'description'  => 'Available one of the fields: "id", "plznr", "gemnam38", "ortnam", "stroffi", "return"',
+    'description'  => 'Available one of the fields: "id", "plznr", "gemnam38", "ortnam", "stroffi", "zustort", "return"',
   ];
   $params['strict_fields_searching'] = [
     'name'         => 'strict_fields_searching',

--- a/api/v3/PostcodeAT/Importstatistikaustria.php
+++ b/api/v3/PostcodeAT/Importstatistikaustria.php
@@ -25,6 +25,12 @@
  */
 function _civicrm_api3_postcode_a_t_Importstatistikaustria_spec(&$spec) {
   $spec['zipfile']['title'] = "Path to zip file if available locally";
+  $spec['error_on_empty'] = [
+    'title'       => 'Error on empty import result?',
+    'description' => 'Indicates whether an empty new data set should raise an error and not overwrite the table data.',
+    'type'        => CRM_Utils_Type::T_BOOLEAN,
+    'api.default' => TRUE,
+  ];
 }
 
 /**
@@ -49,7 +55,9 @@ function civicrm_api3_postcode_a_t_Importstatistikaustria($params) {
     // Put data in temporary table
     $db->importStatistikAustria();
     // Overwrite live table
-    $db->copy();
+    if (!$db->copy($params['error_on_empty'])) {
+      return civicrm_api3_create_error('Received empty data set. Discarding results.', ['error_code' => 'empty_data_set']);
+    }
     // Count total number imported
     $sql = "SELECT COUNT(*) FROM `civicrm_postcodeat`";
     $values['count'] = CRM_Core_DAO::singleValueQuery($sql);

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_postcodeat` (
   `stroffi` varchar(60) NOT NULL,
   `plznr` char(4) NOT NULL,
   `gemnr2` char(5) NOT NULL,
+  `zustort` varchar(75) NULL,
   PRIMARY KEY (`id`),
   KEY (`plznr`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
@@ -22,6 +23,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_statistikaustria_import` (
   `stroffi` varchar(60) NOT NULL,
   `plznr` char(4) NOT NULL,
   `gemnr2` char(5) NOT NULL,
+  `zustort` varchar(75) NULL,
   PRIMARY KEY (`id`),
   KEY (`plznr`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;


### PR DESCRIPTION
This adds a new field `zustort` that was recently introduced and makes the error handling more graceful in scenarios where the received data set is empty, or the parsing logic makes it look like it is empty. Instead of replacing the table data with an empty data set, this will leave the existing data as-is and raise an error instead.